### PR TITLE
Feature/fix cross comp issues with mul div64

### DIFF
--- a/include/math/math.h
+++ b/include/math/math.h
@@ -55,7 +55,10 @@ public:
         \param divider - Divider
         \return Calculated value of (operant * multiplier / divider) expression
     */
+#if defined(__GNUC__) && defined(__SIZEOF_INT128__) || defined(_MSC_VER)
     static uint64_t MulDiv64(uint64_t operant, uint64_t multiplier, uint64_t divider);
+#endif
+
 };
 
 /*! \example math_math.cpp Math example */

--- a/source/math/math.cpp
+++ b/source/math/math.cpp
@@ -14,6 +14,7 @@
 
 namespace CppCommon {
 
+#if defined(__GNUC__) && defined(__SIZEOF_INT128__) || defined(_MSC_VER)
 uint64_t Math::MulDiv64(uint64_t operant, uint64_t multiplier, uint64_t divider)
 {
 #if defined(__GNUC__) && defined(__SIZEOF_INT128__)
@@ -308,5 +309,6 @@ done:
     #error MulDiv64 is no supported!
 #endif
 }
+#endif
 
 } // namespace CppCommon

--- a/source/math/math.cpp
+++ b/source/math/math.cpp
@@ -16,7 +16,7 @@ namespace CppCommon {
 
 uint64_t Math::MulDiv64(uint64_t operant, uint64_t multiplier, uint64_t divider)
 {
-#if defined(__GNUC__)
+#if defined(__GNUC__) && defined(__SIZEOF_INT128__)
     __uint128_t a = operant;
     __uint128_t b = multiplier;
     __uint128_t c = divider;


### PR DESCRIPTION
This PR fixes some issues detected on Ubuntu builds:

https://github.com/tarc/CppCommon/actions/runs/314111379

For all of them, `__uint128_t` is not defined:

```
2020-10-18T18:54:23.3092307Z /home/runner/.conan/data/cppcommon/1.0.0.0/_/_/build/e161ace23ff0767bb22fc8a6cc14ea5303c31571/source_subfolder/source/math/math.cpp:20:5: error: ‘__uint128_t’ was not declared in this scope
2020-10-18T18:54:23.3093797Z      __uint128_t a = operant;
2020-10-18T18:54:23.3094379Z      ^~~~~~~~~~~
```

The only place where `MulDiv64()` is used in this project is in `Timestamp::nano()` and it already `#ifdef`s its usage:

https://github.com/chronoxor/CppCommon/blob/cd78a1142b0d91056d01ab37fd794ea8f9ada185/source/time/timestamp.cpp#L153-L203

I haven't run the tests yet, so I'm posting this PR now and am updating it later after running the tests in case there's something adjustments to make.
