### PR TITLE
Feature/validate alignment requirements

### DIFF
--- a/include/utility/validate_aligned_storage.h
+++ b/include/utility/validate_aligned_storage.h
@@ -1,0 +1,38 @@
+/*!
+    \file validate_aligned_storage.h
+    \brief 
+    \author Tarcisio Rodrigues
+    \date 18.10.2020
+    \copyright MIT License
+*/
+
+#ifndef CPPCOMMON_UTILITY_VALIDATE_ALIGNED_STORAGE_H
+#define CPPCOMMON_UTILITY_VALIDATE_ALIGNED_STORAGE_H
+
+#include <cstddef>
+#include <type_traits>
+
+namespace CppCommon {
+
+    template<const size_t ImplSize, const size_t ImplAlign, const size_t StorageSize, const size_t StorageAlign, class Enable = void>
+    class ValidateAlignedStorage;
+
+    template<const size_t ImplSize, const size_t ImplAlign, const size_t StorageSize, const size_t StorageAlign>
+    class ValidateAlignedStorage
+    <
+        ImplSize,
+        ImplAlign,
+        StorageSize,
+        StorageAlign,
+        typename std::enable_if
+        <
+            StorageAlign % ImplAlign == 0 && ImplSize <= StorageSize
+        >::type
+    >
+    {
+    };
+
+
+} // namespace CppCommon
+
+#endif // CPPCOMMON_UTILITY_VALIDATE_ALIGNED_STORAGE_H

--- a/include/utility/validate_aligned_storage.h
+++ b/include/utility/validate_aligned_storage.h
@@ -30,6 +30,8 @@ namespace CppCommon {
         >::type
     >
     {
+    public:
+        void nop() {}
     };
 
 

--- a/source/errors/exceptions_handler.cpp
+++ b/source/errors/exceptions_handler.cpp
@@ -637,7 +637,7 @@ ExceptionsHandler::ExceptionsHandler()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "ExceptionsHandler::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "ExceptionsHandler::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "ExceptionsHandler::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/errors/exceptions_handler.cpp
+++ b/source/errors/exceptions_handler.cpp
@@ -636,7 +636,7 @@ private:
 
 ExceptionsHandler::ExceptionsHandler()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "ExceptionsHandler::StorageSize must be increased!");

--- a/source/errors/exceptions_handler.cpp
+++ b/source/errors/exceptions_handler.cpp
@@ -12,6 +12,7 @@
 #include "system/stack_trace.h"
 #include "time/timestamp.h"
 #include "utility/resource.h"
+#include "utility/validate_aligned_storage.h"
 
 #include <cstring>
 #include <exception>
@@ -635,6 +636,8 @@ private:
 
 ExceptionsHandler::ExceptionsHandler()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "ExceptionsHandler::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "ExceptionsHandler::StorageAlign must be adjusted!");

--- a/source/filesystem/file.cpp
+++ b/source/filesystem/file.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <cassert>
 #include <cstring>
 
@@ -618,6 +620,8 @@ const size_t File::DEFAULT_BUFFER = 8192;
 
 File::File() : Path()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "File::StorageAlign must be adjusted!");
@@ -628,6 +632,8 @@ File::File() : Path()
 
 File::File(const Path& path) : Path(path)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "File::StorageAlign must be adjusted!");
@@ -638,6 +644,8 @@ File::File(const Path& path) : Path(path)
 
 File::File(const File& file) : Path(file)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "File::StorageAlign must be adjusted!");
@@ -648,6 +656,8 @@ File::File(const File& file) : Path(file)
 
 File::File(File&& file) noexcept : Path(std::move(file))
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "File::StorageAlign must be adjusted!");

--- a/source/filesystem/file.cpp
+++ b/source/filesystem/file.cpp
@@ -620,7 +620,7 @@ const size_t File::DEFAULT_BUFFER = 8192;
 
 File::File() : Path()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
@@ -632,7 +632,7 @@ File::File() : Path()
 
 File::File(const Path& path) : Path(path)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
@@ -644,7 +644,7 @@ File::File(const Path& path) : Path(path)
 
 File::File(const File& file) : Path(file)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
@@ -656,7 +656,7 @@ File::File(const File& file) : Path(file)
 
 File::File(File&& file) noexcept : Path(std::move(file))
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");

--- a/source/filesystem/file.cpp
+++ b/source/filesystem/file.cpp
@@ -620,7 +620,7 @@ File::File() : Path()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "File::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "File::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(this);
@@ -630,7 +630,7 @@ File::File(const Path& path) : Path(path)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "File::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "File::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(this);
@@ -640,7 +640,7 @@ File::File(const File& file) : Path(file)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "File::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "File::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(this);
@@ -650,7 +650,7 @@ File::File(File&& file) noexcept : Path(std::move(file))
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "File::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "File::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "File::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(this);

--- a/source/system/dll.cpp
+++ b/source/system/dll.cpp
@@ -11,6 +11,8 @@
 #include "errors/fatal.h"
 #include "string/format.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <cassert>
 
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
@@ -145,6 +147,8 @@ private:
 
 DLL::DLL()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "DLL::StorageAlign must be adjusted!");
@@ -155,6 +159,8 @@ DLL::DLL()
 
 DLL::DLL(const Path& path, bool load)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "DLL::StorageAlign must be adjusted!");
@@ -170,6 +176,8 @@ DLL::DLL(const Path& path, bool load)
 
 DLL::DLL(const DLL& dll)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "DLL::StorageAlign must be adjusted!");
@@ -182,6 +190,8 @@ DLL::DLL(const DLL& dll)
 
 DLL::DLL(DLL&& dll) noexcept
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "DLL::StorageAlign must be adjusted!");

--- a/source/system/dll.cpp
+++ b/source/system/dll.cpp
@@ -147,7 +147,7 @@ private:
 
 DLL::DLL()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
@@ -159,7 +159,7 @@ DLL::DLL()
 
 DLL::DLL(const Path& path, bool load)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
@@ -176,7 +176,7 @@ DLL::DLL(const Path& path, bool load)
 
 DLL::DLL(const DLL& dll)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
@@ -190,7 +190,7 @@ DLL::DLL(const DLL& dll)
 
 DLL::DLL(DLL&& dll) noexcept
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");

--- a/source/system/dll.cpp
+++ b/source/system/dll.cpp
@@ -147,7 +147,7 @@ DLL::DLL()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "DLL::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "DLL::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();
@@ -157,7 +157,7 @@ DLL::DLL(const Path& path, bool load)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "DLL::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "DLL::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();
@@ -172,7 +172,7 @@ DLL::DLL(const DLL& dll)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "DLL::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "DLL::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();
@@ -184,7 +184,7 @@ DLL::DLL(DLL&& dll) noexcept
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "DLL::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "DLL::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "DLL::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/system/pipe.cpp
+++ b/source/system/pipe.cpp
@@ -183,7 +183,7 @@ private:
 
 Pipe::Pipe()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Pipe::StorageSize must be increased!");

--- a/source/system/pipe.cpp
+++ b/source/system/pipe.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <cassert>
 
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
@@ -181,6 +183,8 @@ private:
 
 Pipe::Pipe()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Pipe::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "Pipe::StorageAlign must be adjusted!");

--- a/source/system/pipe.cpp
+++ b/source/system/pipe.cpp
@@ -183,7 +183,7 @@ Pipe::Pipe()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Pipe::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "Pipe::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "Pipe::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/system/process.cpp
+++ b/source/system/process.cpp
@@ -480,7 +480,7 @@ Process::Process()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "Process::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "Process::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();
@@ -490,7 +490,7 @@ Process::Process(uint64_t id)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "Process::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "Process::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(id);
@@ -500,7 +500,7 @@ Process::Process(const Process& process)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "Process::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "Process::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(process.pid());
@@ -510,7 +510,7 @@ Process::Process(Process&& process) noexcept
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "Process::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "Process::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/system/process.cpp
+++ b/source/system/process.cpp
@@ -13,6 +13,7 @@
 #include "string/format.h"
 #include "threads/thread.h"
 #include "utility/resource.h"
+#include "utility/validate_aligned_storage.h"
 
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
 #include <sys/wait.h>
@@ -478,6 +479,8 @@ private:
 
 Process::Process()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "Process::StorageAlign must be adjusted!");
@@ -488,6 +491,8 @@ Process::Process()
 
 Process::Process(uint64_t id)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "Process::StorageAlign must be adjusted!");
@@ -498,6 +503,8 @@ Process::Process(uint64_t id)
 
 Process::Process(const Process& process)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "Process::StorageAlign must be adjusted!");
@@ -508,6 +515,8 @@ Process::Process(const Process& process)
 
 Process::Process(Process&& process) noexcept
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "Process::StorageAlign must be adjusted!");

--- a/source/system/process.cpp
+++ b/source/system/process.cpp
@@ -479,7 +479,7 @@ private:
 
 Process::Process()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
@@ -491,7 +491,7 @@ Process::Process()
 
 Process::Process(uint64_t id)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
@@ -503,7 +503,7 @@ Process::Process(uint64_t id)
 
 Process::Process(const Process& process)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");
@@ -515,7 +515,7 @@ Process::Process(const Process& process)
 
 Process::Process(Process&& process) noexcept
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Process::StorageSize must be increased!");

--- a/source/system/shared_memory.cpp
+++ b/source/system/shared_memory.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <cassert>
 #include <cstring>
 
@@ -185,6 +187,8 @@ private:
 
 SharedMemory::SharedMemory(const std::string& name, size_t size) : _name(name), _size(size)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "SharedMemory::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "SharedMemory::StorageAlign must be adjusted!");

--- a/source/system/shared_memory.cpp
+++ b/source/system/shared_memory.cpp
@@ -187,7 +187,7 @@ SharedMemory::SharedMemory(const std::string& name, size_t size) : _name(name), 
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "SharedMemory::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "SharedMemory::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "SharedMemory::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(name, size);

--- a/source/system/shared_memory.cpp
+++ b/source/system/shared_memory.cpp
@@ -187,7 +187,7 @@ private:
 
 SharedMemory::SharedMemory(const std::string& name, size_t size) : _name(name), _size(size)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "SharedMemory::StorageSize must be increased!");

--- a/source/system/stack_trace_manager.cpp
+++ b/source/system/stack_trace_manager.cpp
@@ -102,7 +102,7 @@ StackTraceManager::StackTraceManager()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StackTraceManager::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "StackTraceManager::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "StackTraceManager::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/system/stack_trace_manager.cpp
+++ b/source/system/stack_trace_manager.cpp
@@ -102,7 +102,7 @@ private:
 
 StackTraceManager::StackTraceManager()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StackTraceManager::StorageSize must be increased!");

--- a/source/system/stack_trace_manager.cpp
+++ b/source/system/stack_trace_manager.cpp
@@ -8,6 +8,8 @@
 
 #include "system/stack_trace_manager.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
 #if defined(DBGHELP_SUPPORT)
@@ -100,6 +102,8 @@ private:
 
 StackTraceManager::StackTraceManager()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StackTraceManager::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "StackTraceManager::StorageAlign must be adjusted!");

--- a/source/system/stream.cpp
+++ b/source/system/stream.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <cassert>
 
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
@@ -233,6 +235,8 @@ private:
 
 StdInput::StdInput()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StdInput::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "StdInput::StorageAlign must be adjusted!");
@@ -259,6 +263,8 @@ void StdInput::swap(StdInput& stream) noexcept
 
 StdOutput::StdOutput()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StdOutput::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "StdOutput::StorageAlign must be adjusted!");
@@ -286,6 +292,8 @@ void StdOutput::swap(StdOutput& stream) noexcept
 
 StdError::StdError()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StdError::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "StdError::StorageAlign must be adjusted!");

--- a/source/system/stream.cpp
+++ b/source/system/stream.cpp
@@ -235,7 +235,7 @@ private:
 
 StdInput::StdInput()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StdInput::StorageSize must be increased!");
@@ -263,7 +263,7 @@ void StdInput::swap(StdInput& stream) noexcept
 
 StdOutput::StdOutput()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StdOutput::StorageSize must be increased!");
@@ -292,7 +292,7 @@ void StdOutput::swap(StdOutput& stream) noexcept
 
 StdError::StdError()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StdError::StorageSize must be increased!");

--- a/source/system/stream.cpp
+++ b/source/system/stream.cpp
@@ -235,7 +235,7 @@ StdInput::StdInput()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StdInput::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "StdInput::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "StdInput::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();
@@ -261,7 +261,7 @@ StdOutput::StdOutput()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StdOutput::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "StdOutput::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "StdOutput::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();
@@ -288,7 +288,7 @@ StdError::StdError()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "StdError::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "StdError::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "StdError::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/threads/barrier.cpp
+++ b/source/threads/barrier.cpp
@@ -8,6 +8,8 @@
 
 #include "threads/barrier.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <cassert>
 
 #if (defined(unix) || defined(__unix) || defined(__unix__)) && !defined(__APPLE__)
@@ -119,6 +121,8 @@ private:
 
 Barrier::Barrier(int threads)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Barrier::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "Barrier::StorageAlign must be adjusted!");

--- a/source/threads/barrier.cpp
+++ b/source/threads/barrier.cpp
@@ -121,7 +121,7 @@ Barrier::Barrier(int threads)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Barrier::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "Barrier::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "Barrier::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(threads);

--- a/source/threads/barrier.cpp
+++ b/source/threads/barrier.cpp
@@ -121,7 +121,7 @@ private:
 
 Barrier::Barrier(int threads)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Barrier::StorageSize must be increased!");

--- a/source/threads/condition_variable.cpp
+++ b/source/threads/condition_variable.cpp
@@ -119,7 +119,7 @@ ConditionVariable::ConditionVariable()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "ConditionVariable::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "ConditionVariable::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "ConditionVariable::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/threads/condition_variable.cpp
+++ b/source/threads/condition_variable.cpp
@@ -8,6 +8,8 @@
 
 #include "threads/condition_variable.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
@@ -117,6 +119,8 @@ private:
 
 ConditionVariable::ConditionVariable()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "ConditionVariable::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "ConditionVariable::StorageAlign must be adjusted!");

--- a/source/threads/condition_variable.cpp
+++ b/source/threads/condition_variable.cpp
@@ -119,7 +119,7 @@ private:
 
 ConditionVariable::ConditionVariable()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "ConditionVariable::StorageSize must be increased!");

--- a/source/threads/critical_section.cpp
+++ b/source/threads/critical_section.cpp
@@ -110,7 +110,7 @@ CriticalSection::CriticalSection()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "CriticalSection::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "CriticalSection::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "CriticalSection::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/threads/critical_section.cpp
+++ b/source/threads/critical_section.cpp
@@ -110,7 +110,7 @@ private:
 
 CriticalSection::CriticalSection()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "CriticalSection::StorageSize must be increased!");

--- a/source/threads/critical_section.cpp
+++ b/source/threads/critical_section.cpp
@@ -10,6 +10,8 @@
 
 #include "threads/thread.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
 #include "errors/fatal.h"
 #include <pthread.h>
@@ -108,6 +110,8 @@ private:
 
 CriticalSection::CriticalSection()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "CriticalSection::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "CriticalSection::StorageAlign must be adjusted!");

--- a/source/threads/event_auto_reset.cpp
+++ b/source/threads/event_auto_reset.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
@@ -168,6 +170,8 @@ private:
 
 EventAutoReset::EventAutoReset(bool signaled)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "EventAutoReset::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "EventAutoReset::StorageAlign must be adjusted!");

--- a/source/threads/event_auto_reset.cpp
+++ b/source/threads/event_auto_reset.cpp
@@ -170,7 +170,7 @@ EventAutoReset::EventAutoReset(bool signaled)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "EventAutoReset::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "EventAutoReset::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "EventAutoReset::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(signaled);

--- a/source/threads/event_auto_reset.cpp
+++ b/source/threads/event_auto_reset.cpp
@@ -170,7 +170,7 @@ private:
 
 EventAutoReset::EventAutoReset(bool signaled)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "EventAutoReset::StorageSize must be increased!");

--- a/source/threads/event_manual_reset.cpp
+++ b/source/threads/event_manual_reset.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
@@ -181,6 +183,8 @@ private:
 
 EventManualReset::EventManualReset(bool signaled)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "EventManualReset::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "EventManualReset::StorageAlign must be adjusted!");

--- a/source/threads/event_manual_reset.cpp
+++ b/source/threads/event_manual_reset.cpp
@@ -183,7 +183,7 @@ EventManualReset::EventManualReset(bool signaled)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "EventManualReset::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "EventManualReset::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "EventManualReset::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(signaled);

--- a/source/threads/event_manual_reset.cpp
+++ b/source/threads/event_manual_reset.cpp
@@ -183,7 +183,7 @@ private:
 
 EventManualReset::EventManualReset(bool signaled)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "EventManualReset::StorageSize must be increased!");

--- a/source/threads/file_lock.cpp
+++ b/source/threads/file_lock.cpp
@@ -288,7 +288,7 @@ FileLock::FileLock()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "FileLock::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "FileLock::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "FileLock::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();
@@ -298,7 +298,7 @@ FileLock::FileLock(const Path& path) : FileLock()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "FileLock::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "FileLock::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "FileLock::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/threads/file_lock.cpp
+++ b/source/threads/file_lock.cpp
@@ -287,7 +287,7 @@ private:
 
 FileLock::FileLock()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "FileLock::StorageSize must be increased!");
@@ -299,7 +299,7 @@ FileLock::FileLock()
 
 FileLock::FileLock(const Path& path) : FileLock()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "FileLock::StorageSize must be increased!");

--- a/source/threads/file_lock.cpp
+++ b/source/threads/file_lock.cpp
@@ -10,6 +10,7 @@
 
 #include "errors/fatal.h"
 #include "threads/thread.h"
+#include "utility/validate_aligned_storage.h"
 
 #if (defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)) && !defined(__CYGWIN__)
 #include <sys/file.h>
@@ -286,6 +287,8 @@ private:
 
 FileLock::FileLock()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "FileLock::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "FileLock::StorageAlign must be adjusted!");
@@ -296,6 +299,8 @@ FileLock::FileLock()
 
 FileLock::FileLock(const Path& path) : FileLock()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "FileLock::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "FileLock::StorageAlign must be adjusted!");

--- a/source/threads/mutex.cpp
+++ b/source/threads/mutex.cpp
@@ -150,7 +150,7 @@ private:
 
 Mutex::Mutex()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Mutex::StorageSize must be increased!");

--- a/source/threads/mutex.cpp
+++ b/source/threads/mutex.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 
 #if defined(__APPLE__) || defined(__CYGWIN__)
@@ -148,6 +150,8 @@ private:
 
 Mutex::Mutex()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Mutex::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "Mutex::StorageAlign must be adjusted!");

--- a/source/threads/mutex.cpp
+++ b/source/threads/mutex.cpp
@@ -150,7 +150,7 @@ Mutex::Mutex()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Mutex::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "Mutex::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "Mutex::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/threads/named_condition_variable.cpp
+++ b/source/threads/named_condition_variable.cpp
@@ -243,7 +243,7 @@ NamedConditionVariable::NamedConditionVariable(const std::string& name)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedConditionVariable::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "NamedConditionVariable::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "NamedConditionVariable::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(name);

--- a/source/threads/named_condition_variable.cpp
+++ b/source/threads/named_condition_variable.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 
 #if (defined(unix) || defined(__unix) || defined(__unix__)) && !defined(__APPLE__) && !defined(__CYGWIN__)
@@ -241,6 +243,8 @@ private:
 
 NamedConditionVariable::NamedConditionVariable(const std::string& name)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedConditionVariable::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "NamedConditionVariable::StorageAlign must be adjusted!");

--- a/source/threads/named_condition_variable.cpp
+++ b/source/threads/named_condition_variable.cpp
@@ -243,7 +243,7 @@ private:
 
 NamedConditionVariable::NamedConditionVariable(const std::string& name)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedConditionVariable::StorageSize must be increased!");

--- a/source/threads/named_critical_section.cpp
+++ b/source/threads/named_critical_section.cpp
@@ -12,6 +12,7 @@
 #include "system/shared_type.h"
 #include "threads/named_event_auto_reset.h"
 #include "threads/thread.h"
+#include "utility/validate_aligned_storage.h"
 
 #if (defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)) && !defined(__CYGWIN__)
 #include <pthread.h>
@@ -176,6 +177,8 @@ private:
 
 NamedCriticalSection::NamedCriticalSection(const std::string& name)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedCriticalSection::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "NamedCriticalSection::StorageAlign must be adjusted!");

--- a/source/threads/named_critical_section.cpp
+++ b/source/threads/named_critical_section.cpp
@@ -177,7 +177,7 @@ private:
 
 NamedCriticalSection::NamedCriticalSection(const std::string& name)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedCriticalSection::StorageSize must be increased!");

--- a/source/threads/named_critical_section.cpp
+++ b/source/threads/named_critical_section.cpp
@@ -178,7 +178,7 @@ NamedCriticalSection::NamedCriticalSection(const std::string& name)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedCriticalSection::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "NamedCriticalSection::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "NamedCriticalSection::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(name, 4000);

--- a/source/threads/named_event_auto_reset.cpp
+++ b/source/threads/named_event_auto_reset.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 
 #if (defined(unix) || defined(__unix) || defined(__unix__)) && !defined(__APPLE__) && !defined(__CYGWIN__)
@@ -227,6 +229,8 @@ private:
 
 NamedEventAutoReset::NamedEventAutoReset(const std::string& name, bool signaled)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedEventAutoReset::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "NamedEventAutoReset::StorageAlign must be adjusted!");

--- a/source/threads/named_event_auto_reset.cpp
+++ b/source/threads/named_event_auto_reset.cpp
@@ -229,7 +229,7 @@ private:
 
 NamedEventAutoReset::NamedEventAutoReset(const std::string& name, bool signaled)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedEventAutoReset::StorageSize must be increased!");

--- a/source/threads/named_event_auto_reset.cpp
+++ b/source/threads/named_event_auto_reset.cpp
@@ -229,7 +229,7 @@ NamedEventAutoReset::NamedEventAutoReset(const std::string& name, bool signaled)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedEventAutoReset::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "NamedEventAutoReset::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "NamedEventAutoReset::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(name, signaled);

--- a/source/threads/named_event_manual_reset.cpp
+++ b/source/threads/named_event_manual_reset.cpp
@@ -244,7 +244,7 @@ NamedEventManualReset::NamedEventManualReset(const std::string& name, bool signa
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedEventManualReset::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "NamedEventManualReset::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "NamedEventManualReset::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(name, signaled);

--- a/source/threads/named_event_manual_reset.cpp
+++ b/source/threads/named_event_manual_reset.cpp
@@ -244,7 +244,7 @@ private:
 
 NamedEventManualReset::NamedEventManualReset(const std::string& name, bool signaled)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedEventManualReset::StorageSize must be increased!");

--- a/source/threads/named_event_manual_reset.cpp
+++ b/source/threads/named_event_manual_reset.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 
 #if (defined(unix) || defined(__unix) || defined(__unix__)) && !defined(__APPLE__) && !defined(__CYGWIN__)
@@ -242,6 +244,8 @@ private:
 
 NamedEventManualReset::NamedEventManualReset(const std::string& name, bool signaled)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedEventManualReset::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "NamedEventManualReset::StorageAlign must be adjusted!");

--- a/source/threads/named_mutex.cpp
+++ b/source/threads/named_mutex.cpp
@@ -176,7 +176,7 @@ private:
 
 NamedMutex::NamedMutex(const std::string& name)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedMutex::StorageSize must be increased!");

--- a/source/threads/named_mutex.cpp
+++ b/source/threads/named_mutex.cpp
@@ -176,7 +176,7 @@ NamedMutex::NamedMutex(const std::string& name)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedMutex::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "NamedMutex::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "NamedMutex::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(name);

--- a/source/threads/named_mutex.cpp
+++ b/source/threads/named_mutex.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 
 #if defined(__APPLE__)
@@ -174,6 +176,8 @@ private:
 
 NamedMutex::NamedMutex(const std::string& name)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedMutex::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "NamedMutex::StorageAlign must be adjusted!");

--- a/source/threads/named_rw_lock.cpp
+++ b/source/threads/named_rw_lock.cpp
@@ -11,6 +11,7 @@
 #include "errors/fatal.h"
 #include "system/shared_type.h"
 #include "threads/thread.h"
+#include "utility/validate_aligned_storage.h"
 
 #if (defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)) && !defined(__CYGWIN__)
 #include <fcntl.h>
@@ -505,6 +506,8 @@ private:
 
 NamedRWLock::NamedRWLock(const std::string& name)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedRWLock::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "NamedRWLock::StorageAlign must be adjusted!");

--- a/source/threads/named_rw_lock.cpp
+++ b/source/threads/named_rw_lock.cpp
@@ -507,7 +507,7 @@ NamedRWLock::NamedRWLock(const std::string& name)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedRWLock::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "NamedRWLock::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "NamedRWLock::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(name, 4000);

--- a/source/threads/named_rw_lock.cpp
+++ b/source/threads/named_rw_lock.cpp
@@ -506,7 +506,7 @@ private:
 
 NamedRWLock::NamedRWLock(const std::string& name)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedRWLock::StorageSize must be increased!");

--- a/source/threads/named_semaphore.cpp
+++ b/source/threads/named_semaphore.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 #include <cassert>
 
@@ -182,6 +184,8 @@ private:
 
 NamedSemaphore::NamedSemaphore(const std::string& name, int resources)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedSemaphore::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "NamedSemaphore::StorageAlign must be adjusted!");

--- a/source/threads/named_semaphore.cpp
+++ b/source/threads/named_semaphore.cpp
@@ -184,7 +184,7 @@ NamedSemaphore::NamedSemaphore(const std::string& name, int resources)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedSemaphore::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "NamedSemaphore::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "NamedSemaphore::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(name, resources);

--- a/source/threads/named_semaphore.cpp
+++ b/source/threads/named_semaphore.cpp
@@ -184,7 +184,7 @@ private:
 
 NamedSemaphore::NamedSemaphore(const std::string& name, int resources)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "NamedSemaphore::StorageSize must be increased!");

--- a/source/threads/rw_lock.cpp
+++ b/source/threads/rw_lock.cpp
@@ -129,7 +129,7 @@ RWLock::RWLock()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "RWLock::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "RWLock::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "RWLock::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();

--- a/source/threads/rw_lock.cpp
+++ b/source/threads/rw_lock.cpp
@@ -129,7 +129,7 @@ private:
 
 RWLock::RWLock()
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "RWLock::StorageSize must be increased!");

--- a/source/threads/rw_lock.cpp
+++ b/source/threads/rw_lock.cpp
@@ -10,6 +10,8 @@
 
 #include "threads/thread.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
 #include "errors/fatal.h"
 #include <pthread.h>
@@ -127,6 +129,8 @@ private:
 
 RWLock::RWLock()
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "RWLock::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "RWLock::StorageAlign must be adjusted!");

--- a/source/threads/semaphore.cpp
+++ b/source/threads/semaphore.cpp
@@ -156,7 +156,7 @@ private:
 
 Semaphore::Semaphore(int resources)
 {
-    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _.nop();
 
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Semaphore::StorageSize must be increased!");

--- a/source/threads/semaphore.cpp
+++ b/source/threads/semaphore.cpp
@@ -10,6 +10,8 @@
 
 #include "errors/fatal.h"
 
+#include "utility/validate_aligned_storage.h"
+
 #include <algorithm>
 #include <cassert>
 
@@ -154,6 +156,8 @@ private:
 
 Semaphore::Semaphore(int resources)
 {
+    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
+
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Semaphore::StorageSize must be increased!");
     static_assert((StorageAlign % alignof(Impl) == 0), "Semaphore::StorageAlign must be adjusted!");

--- a/source/threads/semaphore.cpp
+++ b/source/threads/semaphore.cpp
@@ -156,7 +156,7 @@ Semaphore::Semaphore(int resources)
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "Semaphore::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "Semaphore::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "Semaphore::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl(resources);


### PR DESCRIPTION
I'm facing some issues related to `std::aligned_storage<>`. In a few platforms the values chosen throughout CppCommon for `StorageAlign` are not equal to `alignof(Impl)`. This failures are due to `static_assert()`s like this:

https://github.com/chronoxor/CppCommon/blob/2630dbb46bfdea7292a0b1fcaa0f3984e249d7f1/source/errors/exceptions_handler.cpp#L636-L644

Is this really required? I can see that the standard requires only that `alignof(Impl)` be a divisor of `StorageAlign` (see, for instance, [`std::aligned_storage` on cppreference](https://en.cppreference.com/w/cpp/types/aligned_storage)). Assuming this is the case, I'm proposing at first to relax the assertion:

https://github.com/chronoxor/CppCommon/blob/384d186d41a71cecd86c20167627c055d7771e28/source/errors/exceptions_handler.cpp#L643

Such a issue is hard to fix, because the failure gives no clue to the value of the compiler time constant `alignof(Impl)`. Given that it's ok to change the assertion as above, I'm proposing a way to force the compiler to output the values:

https://github.com/chronoxor/CppCommon/blob/384d186d41a71cecd86c20167627c055d7771e28/include/utility/validate_aligned_storage.h#L17-L33

And then:

https://github.com/chronoxor/CppCommon/blob/384d186d41a71cecd86c20167627c055d7771e28/source/errors/exceptions_handler.cpp#L637-L647

This is a well known technique to force the compiler to output values as compilations errors. The change above triggers some errors in a few platforms:

```
[ 18%] Building CXX object source_subfolder/CMakeFiles/cppcommon.dir/source/errors/system_error.cpp.o
/home/conan/w/cci_PR-3224/.conan/data/cppcommon/1.0.0.0/_/_/build/135337621df01fbab236be41fff9389f348da67b/source_subfolder/source/errors/exceptions_handler.cpp:639:86: error: implicit instantiation of undefined template 'CppCommon::ValidateAlignedStorage<64, 16, 72, 8, void>'
    ValidateAlignedStorage< sizeof(Impl), alignof(Impl), StorageSize, StorageAlign > _; _;
                                                                                     ^
/home/conan/w/cci_PR-3224/.conan/data/cppcommon/1.0.0.0/_/_/build/135337621df01fbab236be41fff9389f348da67b/source_subfolder/include/utility/validate_aligned_storage.h:18:11: note: template is declared here
    class ValidateAlignedStorage;
          ^
/home/conan/w/cci_PR-3224/.conan/data/cppcommon/1.0.0.0/_/_/build/135337621df01fbab236be41fff9389f348da67b/source_subfolder/source/errors/exceptions_handler.cpp:643:5: error: static_assert failed "ExceptionsHandler::StorageAlign must be adjusted!"
    static_assert((StorageAlign % alignof(Impl) == 0), "ExceptionsHandler::StorageAlign must be adjusted!");
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```

The interesting part is where it says:

```
implicit instantiation of undefined template 'CppCommon::ValidateAlignedStorage<64, 16, 72, 8, void>'
```

This error, for instance, was obtained on a x64, clang (6.0), libc++, linux build.

I have a patch for this, but I guess it would make sense to keep the relaxed assert and the compiler time trick in a separated PR.