### PR TITLE
Feature/fix alignment issue

### DIFF
--- a/include/errors/exceptions_handler.h
+++ b/include/errors/exceptions_handler.h
@@ -69,7 +69,7 @@ private:
     const Impl& impl() const noexcept { return reinterpret_cast<Impl const&>(_storage); }
 
     static const size_t StorageSize = 72;
-#if defined(__APPLE__)
+#if defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
     static const size_t StorageAlign = 16;
 #else
     static const size_t StorageAlign = 8;

--- a/source/errors/exceptions_handler.cpp
+++ b/source/errors/exceptions_handler.cpp
@@ -637,7 +637,7 @@ ExceptionsHandler::ExceptionsHandler()
 {
     // Check implementation storage parameters
     static_assert((sizeof(Impl) <= StorageSize), "ExceptionsHandler::StorageSize must be increased!");
-    static_assert((alignof(Impl) == StorageAlign), "ExceptionsHandler::StorageAlign must be adjusted!");
+    static_assert((StorageAlign % alignof(Impl) == 0), "ExceptionsHandler::StorageAlign must be adjusted!");
 
     // Create the implementation instance
     new(&_storage)Impl();


### PR DESCRIPTION
This fixes #8 

The errors I am getting are all like this one:

```
/home/conan/w/cci_PR-3224/.conan/data/cppcommon/1.0.0.0/_/_/build/8eca6b297f7067497d8af873e8c5d371fe231849/source_subfolder/source/errors/exceptions_handler.cpp:640:5: error: static_assert failed due to requirement 'alignof(CppCommon::ExceptionsHandler::Impl) == StorageAlign' "ExceptionsHandler::StorageAlign must be adjusted!"
    static_assert((alignof(Impl) == StorageAlign), "ExceptionsHandler::StorageAlign must be adjusted!");
    ^              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

With the help of a helper class to force the compiler output the compile time values, it's possible to see that `alignof(Impl)` is 16 whereas `StorageAlign` is 8 in the above case. The right fix is the following:

https://github.com/chronoxor/CppCommon/blob/c8af1c5d7ac6a3f1a3add073f5f342d13394f6a8/include/errors/exceptions_handler.h#L72-L77

To make travis pass, I'm changing the assert on the cpp to:

https://github.com/chronoxor/CppCommon/blob/4bf24031fbb6c1ce16349d35d7df7a201da6581a/source/errors/exceptions_handler.cpp#L640

It seems the strict equality is not required. For instance, consider this comment from [cppreference on `std::aligned_storage<>`](https://en.cppreference.com/w/cpp/types/aligned_storage), (emphasis mine):

> Provides the nested type type, which is a trivial standard-layout type suitable for use as uninitialized storage for any object whose size is at most Len and whose **alignment requirement is a divisor of Align**.

Is the assertion really required? Does it make sense to change it as above to validate only the divisibility of `StorageAlign` by `alignof(Impl)`?
