### PR TITLE
Update Catch2 branch name from "master" to "v2.x"

### DIFF
--- a/.gitlinks
+++ b/.gitlinks
@@ -1,5 +1,5 @@
 # Modules
-Catch2 modules/Catch2 https://github.com/catchorg/Catch2.git master
+Catch2 modules/Catch2 https://github.com/catchorg/Catch2.git v2.x
 CppBenchmark modules/CppBenchmark https://github.com/chronoxor/CppBenchmark.git master
 fmt modules/fmt https://github.com/fmtlib/fmt.git master
 


### PR DESCRIPTION
"master" is no longer a valid branch