### PR TITLE
Fix  typos

### DIFF
--- a/include/cache/filecache.h
+++ b/include/cache/filecache.h
@@ -34,7 +34,7 @@ namespace CppCommon {
 class FileCache
 {
 public:
-    //! File cache insert hanlder type
+    //! File cache insert handler type
     typedef std::function<bool (FileCache& cache, const std::string& key, const std::string& value, const Timespan& timeout)> InsertHandler;
 
     FileCache() = default;

--- a/source/errors/exceptions_handler.cpp
+++ b/source/errors/exceptions_handler.cpp
@@ -104,7 +104,7 @@ public:
         // Prepare signal action structure
         struct sigaction sa;
         memset(&sa, 0, sizeof(sa));
-        sa.sa_sigaction = SignalHanlder;
+        sa.sa_sigaction = SignalHandler;
         sa.sa_flags = SA_SIGINFO;
 
         // Define signals to catch
@@ -561,7 +561,7 @@ private:
 #elif defined(unix) || defined(__unix) || defined(__unix__) || defined(__APPLE__)
 
     // Signal handler
-    static void SignalHanlder(int signo, siginfo_t* info, void* context)
+    static void SignalHandler(int signo, siginfo_t* info, void* context)
     {
         // Output error
         switch (signo)


### PR DESCRIPTION
Fix typos from `hanlder` to `handler`