### PR TITLE
Update vprint method with latest fmt (11.0.2) changes.

### DIFF
--- a/include/string/format.inl
+++ b/include/string/format.inl
@@ -29,7 +29,7 @@ inline void print(fmt::format_string<T...> pattern, T&&... args)
 template <typename... T>
 inline void print(fmt::wformat_string<T...> pattern, T&&... args)
 {
-    return fmt::vprint<wchar_t>(pattern, fmt::make_format_args<fmt::wformat_context>(args...));
+    return fmt::vprint(pattern, fmt::make_format_args<fmt::wformat_context>(args...));
 }
 
 template <typename TOutputStream, typename... T>
@@ -41,7 +41,7 @@ inline void print(TOutputStream& stream, fmt::format_string<T...> pattern, T&&..
 template <typename TOutputStream, typename... T>
 inline void print(TOutputStream& stream, fmt::wformat_string<T...> pattern, T&&... args)
 {
-    return fmt::vprint<wchar_t>(stream, pattern, fmt::make_format_args<fmt::wformat_context>(args...));
+    return fmt::vprint(stream, pattern, fmt::make_format_args<fmt::wformat_context>(args...));
 }
 
 } // namespace CppCommon


### PR DESCRIPTION
Hello @chronoxor 
A small patch to fix compilation issue due to update on fmt (11.0.2).
It was updated here. [HERE](https://github.com/fmtlib/fmt/commit/cc3ff1529d2c823f0bd2787d1f29da7e16fbaba5#diff-39be774d509c569b421ee9c510ad5f6d306f4a187ce4540b03c761d77a087b32R113) which removed the std::basic_ostream<Char> 👉  to std::ostream& os

⚠️ Would Need testing
